### PR TITLE
added U+2614 to defaults as :rain:

### DIFF
--- a/common/src/main/java/dev/norbiros/emojitype/EmojiType.java
+++ b/common/src/main/java/dev/norbiros/emojitype/EmojiType.java
@@ -84,6 +84,7 @@ public class EmojiType {
 			add(new EmojiCode(":snowman:", "⛄"));
 			add(new EmojiCode(":storm:", "⛈"));
 			add(new EmojiCode(":snow:", "❄"));
+			add(new EmojiCode(":rain:","☔"));
 
 			// Control
 			add(new EmojiCode(":eject:", "⏏"));


### PR DESCRIPTION
minecraft's font has support for the emoji U+2614 (☔) - this simply adds it to the default list