### PR TITLE
fix: add include `snakeyaml` dependency to build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,6 @@ subprojects {
     dependencies {
         minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
 
-        include 'org.yaml:snakeyaml:2.4'
         implementation 'org.yaml:snakeyaml:2.4'
 
         mappings loom.layered {

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,8 @@ subprojects {
 
     dependencies {
         minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
+
+        include 'org.yaml:snakeyaml:2.4'
         implementation 'org.yaml:snakeyaml:2.4'
 
         mappings loom.layered {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -7,6 +7,8 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${project.fabric_loader_version}"
     modApi "com.terraformersmc:modmenu:${project.modmenu_version}"
 
+    include 'org.yaml:snakeyaml:2.4'
+
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
     shadowCommon(project(path: ":common", configuration: "transformProductionFabric")) { transitive false }
 }

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -6,6 +6,8 @@ architectury {
 dependencies {
     neoForge "net.neoforged:neoforge:${project.neoforge_version}"
 
+    include 'org.yaml:snakeyaml:2.4'
+
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
     shadowCommon(project(path: ":common", configuration: "transformProductionNeoForge")) { transitive = false }
 }


### PR DESCRIPTION
You forgot to add `snakeyaml` as `include` dependency in gradle build,
without it wouldn't put the dependency to the actual release build.

So please recompile and rebuild your project with this fix,
so community can use your mod without any problems.