### PR TITLE
feat: add Fabric 26.1.2 Support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,83 +1,10 @@
 plugins {
     java
-    alias(libs.plugins.shadow) apply false
-    alias(libs.plugins.architectury)
-    alias(libs.plugins.architectury.loom) apply false
-}
-
-architectury {
-    minecraft = libs.versions.minecraft.get()
-}
-
-val rootLibs = libs
-
-subprojects {
-    apply(plugin = "com.gradleup.shadow")
-    apply(plugin = "dev.architectury.loom")
-
-    val common: Configuration by configurations.creating
-    val shadowCommon: Configuration by configurations.creating // Don't use shadow from the shadow plugin because we don't want IDEA to index this.
-    val compileClasspath: Configuration by configurations.getting
-    val runtimeClasspath: Configuration by configurations.getting
-
-    compileClasspath.extendsFrom(common)
-    runtimeClasspath.extendsFrom(common)
-
-    configurations.configureEach {
-        if (name == "developmentFabric") {
-            extendsFrom(common)
-        }
-    }
-
-    tasks.processResources {
-        val resourceTargets = listOf(
-            "fabric.mod.json",
-            "META-INF/neoforge.mods.toml",
-        )
-
-        val replaceProperties = mapOf(
-            "version" to project.property("mod_version"),
-            "fabric_minecraft_version_range" to project.property("fabric_minecraft_version_range"),
-            "neo_version_range" to project.property("neo_minecraft_version_range"),
-            "fabric_loader_version" to rootLibs.versions.fabric.loader.get(),
-            "modmenu_version" to rootLibs.versions.modmenu.get(),
-        )
-
-        inputs.properties(replaceProperties)
-        filesMatching(resourceTargets) {
-            expand(replaceProperties)
-        }
-    }
-
-    configure<net.fabricmc.loom.api.LoomGradleExtensionAPI> {
-        silentMojangMappingsLicense()
-    }
-
-    dependencies {
-        "minecraft"(rootLibs.minecraft)
-        implementation(rootLibs.snakeyaml)
-
-        val loom = project.extensions.getByType<net.fabricmc.loom.api.LoomGradleExtensionAPI>()
-        "mappings"(loom.layered {
-            mappings(rootLibs.yarn.mappings.get().toString() + ":v2")
-            mappings(rootLibs.neoforge.yarn.mappings.patch.get().toString())
-        })
-    }
-
-    tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {
-        exclude("architectury.common.json")
-        configurations = listOf(shadowCommon)
-        archiveClassifier.set("dev-shadow")
-    }
-
-    tasks.jar {
-        archiveClassifier.set("dev")
-    }
+    alias(libs.plugins.fabric.loom) apply false
 }
 
 allprojects {
     apply(plugin = "java")
-    apply(plugin = "architectury-plugin")
     apply(plugin = "maven-publish")
 
     base.archivesName.set(project.property("mod_id") as String)
@@ -85,20 +12,18 @@ allprojects {
     group = project.property("maven_group") as String
 
     repositories {
-        // Architectury
-        maven("https://maven.shedaniel.me/")
         // ModMenu
         maven("https://maven.terraformersmc.com/")
-        // NeoForge
-        maven("https://maven.neoforged.net/releases/")
     }
 
     tasks.withType<JavaCompile> {
         options.encoding = "UTF-8"
-        options.release.set(21)
+        options.release.set(25)
     }
 
     configure<JavaPluginExtension> {
         withSourcesJar()
+        sourceCompatibility = JavaVersion.VERSION_25
+        targetCompatibility = JavaVersion.VERSION_25
     }
 }

--- a/common/src/main/java/dev/norbiros/emojitype/EmojiType.java
+++ b/common/src/main/java/dev/norbiros/emojitype/EmojiType.java
@@ -1,10 +1,10 @@
 package dev.norbiros.emojitype;
 
-import dev.architectury.injectables.annotations.ExpectPlatform;
 import dev.norbiros.emojitype.config.ConfigManager;
 import dev.norbiros.emojitype.emoji.EmojiCode;
 import dev.norbiros.emojitype.packs.PackLoader;
 import dev.norbiros.emojitype.packs.types.EmojiPack;
+import net.fabricmc.loader.api.FabricLoader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Contract;
@@ -103,10 +103,8 @@ public class EmojiType {
         return config.enabledPacks.contains(packName);
     }
 
-    @ExpectPlatform
     @Contract(value = "-> _", pure = true)
     public static Path getConfigDirectory() {
-        //noinspection Contract
-        throw new AssertionError("Missing implementation of EmojiType.getConfigDirectory()");
+        return FabricLoader.getInstance().getConfigDir();
     }
 }

--- a/common/src/main/java/dev/norbiros/emojitype/config/ui/EmojiTypeConfig.java
+++ b/common/src/main/java/dev/norbiros/emojitype/config/ui/EmojiTypeConfig.java
@@ -1,33 +1,25 @@
 package dev.norbiros.emojitype.config.ui;
 
 import dev.norbiros.emojitype.EmojiType;
-import dev.norbiros.emojitype.emoji.EmojiCode;
 import dev.norbiros.emojitype.packs.PackLoader;
-import dev.norbiros.emojitype.packs.types.EmojiPack;
-import dev.norbiros.emojitype.packs.types.LocalPack;
 import dev.norbiros.emojitype.utils.DesktopUtils;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.gui.widget.DirectionalLayoutWidget;
-import net.minecraft.client.gui.widget.ThreePartsLayoutWidget;
-import net.minecraft.client.toast.SystemToast;
-import net.minecraft.text.Text;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.layouts.HeaderAndFooterLayout;
+import net.minecraft.client.gui.layouts.LinearLayout;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 public class EmojiTypeConfig extends Screen {
-    public final ThreePartsLayoutWidget layout = new ThreePartsLayoutWidget(this);
-    protected final Screen parent;
-    private @Nullable PackListWidget body;
+    private final HeaderAndFooterLayout layout = new HeaderAndFooterLayout(this);
+    private final @Nullable Screen parent;
 
-    public EmojiTypeConfig(Screen parent) {
-        super(Text.translatable("config.emojitype.packs_title"));
+    public EmojiTypeConfig(@Nullable Screen parent) {
+        super(Component.translatable("config.emojitype.packs_title"));
         this.parent = parent;
-        this.layout.setHeaderHeight(30);
-        this.layout.setFooterHeight(30);
+        this.layout.setHeaderHeight(40);
+        this.layout.setFooterHeight(40);
         EmojiType.reloadPacksFromDisk();
     }
 
@@ -37,112 +29,29 @@ public class EmojiTypeConfig extends Screen {
 
     @Override
     protected void init() {
-        this.layout.addHeader(this.title, this.textRenderer);
+        this.layout.addTitleHeader(this.title, this.font);
 
-        PackListWidget packListWidget = new PackListWidget(client, width, height - 30 - 30, 30, 46, this);
+        LinearLayout footer = LinearLayout.horizontal().spacing(8);
+        footer.addChild(Button.builder(Component.translatable("config.emojitype.back"), button -> this.onClose()).width(100).build());
+        footer.addChild(Button.builder(Component.translatable("config.emojitype.open_folder"), button -> DesktopUtils.openInFileManager(PackLoader.PACKS_DIRECTORY)).width(120).build());
+        footer.addChild(Button.builder(Component.translatable("config.emojitype.reload_packs"), button -> EmojiType.reloadPacksFromDisk()).width(120).build());
+        this.layout.addToFooter(footer);
 
-        Map<String, EmojiPack> availablePacks = EmojiType.getAvailablePacks();
-        for (Map.Entry<String, EmojiPack> entry : availablePacks.entrySet()) {
-            packListWidget.addPack(entry.getValue());
-        }
-
-        this.body = this.layout.addBody(packListWidget);
-
-        this.initFooter();
-
-        this.layout.forEachChild(this::addDrawableChild);
-        this.refreshWidgetPositions();
-    }
-
-    protected void refreshWidgetPositions() {
-        this.layout.refreshPositions();
-        if (this.body != null) {
-            this.body.position(this.width, this.layout);
-        }
-    }
-
-    protected void initFooter() {
-        DirectionalLayoutWidget footerLayout = this.layout.addFooter(DirectionalLayoutWidget.horizontal()).spacing(8);
-
-        footerLayout.add(ButtonWidget.builder(Text.translatable("config.emojitype.back"), button -> this.close()).width(100).build());
-
-        footerLayout.add(ButtonWidget.builder(Text.translatable("config.emojitype.open_folder"), button -> {
-            DesktopUtils.openInFileManager(PackLoader.PACKS_DIRECTORY);
-        }).width(120).build());
-
-        footerLayout.add(ButtonWidget.builder(Text.translatable("config.emojitype.create_new_pack"), button -> this.createNewPack()).width(120).build());
-
-        footerLayout.add(ButtonWidget.builder(Text.translatable("config.emojitype.reload_packs"), button -> {
-            EmojiType.reloadPacksFromDisk();
-            this.refreshScreen();
-        }).width(100).build());
-    }
-
-    private void refreshScreen() {
-        if (this.client != null) {
-            this.client.setScreen(new EmojiTypeConfig(this.parent));
-        }
+        this.layout.visitChildren(element -> {
+            if (element instanceof AbstractWidget widget) {
+                this.addRenderableWidget(widget);
+            }
+        });
+        this.repositionElements();
     }
 
     @Override
-    public void close() {
-        if (this.client != null) {
-            this.client.setScreen(this.parent);
-        }
+    protected void repositionElements() {
+        this.layout.arrangeElements();
     }
 
-    private void createNewPack() {
-        if (this.client != null) {
-            this.client.setScreen(PackPropertiesDialog.createNew(this, (fileName, name, description) -> {
-                // Check if filename ends with .yaml or .yml
-                if (!fileName.endsWith(".yaml") && !fileName.endsWith(".yml")) {
-                    fileName += ".yaml";
-                }
-                
-                // Check for duplicates and show toast if exists
-                if (EmojiType.getAvailablePacks().containsKey(fileName)) {
-                    if (this.client != null) {
-                        this.client.getToastManager().add(new net.minecraft.client.toast.SystemToast(
-                            SystemToast.Type.PACK_LOAD_FAILURE,
-                            Text.translatable("config.emojitype.pack_duplicate_title"),
-                            Text.translatable("config.emojitype.pack_duplicate_message", fileName)
-                        ));
-                    }
-                    return;
-                }
-
-                LocalPack newPack = new LocalPack(name, description);
-
-                List<EmojiCode> emojiCodes = new ArrayList<>();
-                emojiCodes.add(new EmojiCode("", ""));
-                newPack.setEmojiCodes(emojiCodes);
-
-                newPack.setFileName(fileName);
-
-                if (newPack.save()) {
-                    EmojiType.LOGGER.info("Created new pack: {}", fileName);
-
-                    EmojiType.reloadPacksFromDisk();
-                    EmojiType.enablePack(fileName);
-
-                    EmojiPack reloadedPack = EmojiType.getAvailablePacks().get(fileName);
-
-                    if (this.client != null && reloadedPack != null) {
-                        this.client.setScreen(new PackEditorScreen(new EmojiTypeConfig(this.parent), fileName, reloadedPack));
-                    } else {
-                        this.refreshScreen();
-                    }
-                } else {
-                    EmojiType.LOGGER.error("Failed to create new pack");
-                    this.refreshScreen();
-                }
-            }));
-        }
-    }
-
-    public void openPackEditor(String packFileName, EmojiPack pack) {
-        if (this.client != null) {
-            this.client.setScreen(new PackEditorScreen(this, packFileName, pack));
-        }
+    @Override
+    public void onClose() {
+        this.minecraft.setScreen(this.parent);
     }
 }

--- a/common/src/main/java/dev/norbiros/emojitype/mixin/ChatInputSuggestorAccessor.java
+++ b/common/src/main/java/dev/norbiros/emojitype/mixin/ChatInputSuggestorAccessor.java
@@ -1,13 +1,12 @@
 package dev.norbiros.emojitype.mixin;
 
-
-import net.minecraft.client.gui.screen.ChatInputSuggestor;
-import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.client.gui.components.CommandSuggestions;
+import net.minecraft.client.gui.components.EditBox;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
-@Mixin(ChatInputSuggestor.class)
+@Mixin(CommandSuggestions.class)
 public interface ChatInputSuggestorAccessor {
-    @Accessor
-    TextFieldWidget getTextField();
+    @Accessor("input")
+    EditBox emojitype$getInput();
 }

--- a/common/src/main/java/dev/norbiros/emojitype/mixin/ChatInputSuggestorMixin.java
+++ b/common/src/main/java/dev/norbiros/emojitype/mixin/ChatInputSuggestorMixin.java
@@ -5,9 +5,9 @@ import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import dev.norbiros.emojitype.EmojiType;
-import net.minecraft.client.gui.screen.ChatInputSuggestor;
-import net.minecraft.client.gui.widget.TextFieldWidget;
-import net.minecraft.command.CommandSource;
+import net.minecraft.client.gui.components.CommandSuggestions;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.commands.SharedSuggestionProvider;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -20,47 +20,48 @@ import java.util.concurrent.CompletableFuture;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-@Mixin(ChatInputSuggestor.class)
+@Mixin(CommandSuggestions.class)
 public abstract class ChatInputSuggestorMixin {
     private static final Pattern COLON_PATTERN = Pattern.compile("(:)");
     private static final Pattern WHITESPACE_PATTERN = Pattern.compile("(\\s+)");
 
     @Shadow
     @Final
-    TextFieldWidget textField;
+    private EditBox input;
 
     @Shadow
     @Nullable
     private CompletableFuture<Suggestions> pendingSuggestions;
+
     @Shadow
     @Final
-    private boolean slashOptional;
+    private boolean commandsOnly;
 
     @Shadow
-    public abstract void show(boolean narrateFirstSuggestion);
+    public abstract void showSuggestions(boolean narrateFirstSuggestion);
 
-    @Inject(method = "refresh", at = @At("TAIL"), cancellable = true)
+    @Inject(method = "updateCommandInfo", at = @At("TAIL"), cancellable = true)
     private void inject(CallbackInfo ci) {
-        String text = this.textField.getText();
+        String text = this.input.getValue();
         StringReader stringReader = new StringReader(text);
         boolean hasSlash = stringReader.canRead() && stringReader.peek() == '/';
         if (hasSlash) {
             stringReader.skip();
         }
-        boolean isCommand = this.slashOptional || hasSlash;
-        int cursor = this.textField.getCursor();
+        boolean isCommand = this.commandsOnly || hasSlash;
+        int cursor = this.input.getCursorPosition();
         if (!isCommand) {
             String textUptoCursor = text.substring(0, cursor);
             int start = Math.max(getLastPattern(textUptoCursor, COLON_PATTERN) - 1, 0);
             int whitespace = getLastPattern(textUptoCursor, WHITESPACE_PATTERN);
             if (start < textUptoCursor.length() && start >= whitespace) {
                 if (textUptoCursor.charAt(start) == ':') {
-                    this.pendingSuggestions = CommandSource.suggestMatching(EmojiType.getChatSuggestions(), new SuggestionsBuilder(textUptoCursor, start));
+                    this.pendingSuggestions = SharedSuggestionProvider.suggest(EmojiType.getChatSuggestions(), new SuggestionsBuilder(textUptoCursor, start));
                     this.pendingSuggestions.thenRun(() -> {
                         if (!this.pendingSuggestions.isDone()) {
                             return;
                         }
-                        this.show(false);
+                        this.showSuggestions(false);
                     });
                     ci.cancel();
                 }

--- a/common/src/main/java/dev/norbiros/emojitype/mixin/SelectionManagerMixin.java
+++ b/common/src/main/java/dev/norbiros/emojitype/mixin/SelectionManagerMixin.java
@@ -2,7 +2,7 @@ package dev.norbiros.emojitype.mixin;
 
 import dev.norbiros.emojitype.EmojiType;
 import dev.norbiros.emojitype.emoji.EmojiCode;
-import net.minecraft.client.util.SelectionManager;
+import net.minecraft.client.gui.font.TextFieldHelper;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -14,36 +14,36 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-@Mixin(SelectionManager.class)
+@Mixin(TextFieldHelper.class)
 public abstract class SelectionManagerMixin {
 
     @Shadow
-    private int selectionStart;
+    private int cursorPos;
 
     @Shadow
-    private int selectionEnd;
-
-    @Shadow
-    @Final
-    private Supplier<String> stringGetter;
+    private int selectionPos;
 
     @Shadow
     @Final
-    private Consumer<String> stringSetter;
+    private Supplier<String> getMessageFn;
+
+    @Shadow
+    @Final
+    private Consumer<String> setMessageFn;
 
     @Inject(method = "insert(Ljava/lang/String;Ljava/lang/String;)V", at = @At("TAIL"))
     private void onInsert(String _unused, String insertion, CallbackInfo callbackInfo) {
-        String result = stringGetter.get();
+        String result = getMessageFn.get();
         for (EmojiCode emojiCode : EmojiType.getActiveEmojiCodes()) {
             result = result.replace(emojiCode.getCodeWithColons(), emojiCode.getEmoji());
         }
 
-        if (!Objects.equals(stringGetter.get(), result)) {
-            int lengthDifference = stringGetter.get().length() - result.length();
-            int newCursorPosition = Math.max(Math.min(this.selectionEnd - lengthDifference + 1, result.length()), 0);
-            this.selectionEnd = this.selectionStart = newCursorPosition;
+        if (!Objects.equals(getMessageFn.get(), result)) {
+            int lengthDifference = getMessageFn.get().length() - result.length();
+            int newCursorPosition = Math.max(Math.min(this.selectionPos - lengthDifference + 1, result.length()), 0);
+            this.selectionPos = this.cursorPos = newCursorPosition;
         }
 
-        stringSetter.accept(result);
+        setMessageFn.accept(result);
     }
 }

--- a/common/src/main/java/dev/norbiros/emojitype/mixin/SelectionManagerMixin.java
+++ b/common/src/main/java/dev/norbiros/emojitype/mixin/SelectionManagerMixin.java
@@ -31,7 +31,7 @@ public abstract class SelectionManagerMixin {
     @Final
     private Consumer<String> setMessageFn;
 
-    @Inject(method = "insert(Ljava/lang/String;Ljava/lang/String;)V", at = @At("TAIL"))
+    @Inject(method = "insertText(Ljava/lang/String;Ljava/lang/String;)V", at = @At("TAIL"))
     private void onInsert(String _unused, String insertion, CallbackInfo callbackInfo) {
         String result = getMessageFn.get();
         for (EmojiCode emojiCode : EmojiType.getActiveEmojiCodes()) {

--- a/common/src/main/java/dev/norbiros/emojitype/mixin/SuggestionWindowMixin.java
+++ b/common/src/main/java/dev/norbiros/emojitype/mixin/SuggestionWindowMixin.java
@@ -3,8 +3,8 @@ package dev.norbiros.emojitype.mixin;
 import com.mojang.brigadier.suggestion.Suggestion;
 import dev.norbiros.emojitype.EmojiType;
 import dev.norbiros.emojitype.emoji.EmojiCode;
-import net.minecraft.client.gui.screen.ChatInputSuggestor;
-import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.client.gui.components.CommandSuggestions;
+import net.minecraft.client.gui.components.EditBox;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -14,43 +14,37 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.List;
 
-@Mixin(ChatInputSuggestor.SuggestionWindow.class)
+@Mixin(CommandSuggestions.SuggestionsList.class)
 public abstract class SuggestionWindowMixin {
 
     @Shadow
     @Final
-    ChatInputSuggestor field_21615;
+    CommandSuggestions this$0;
 
     @Shadow
-    private int selection;
+    private int current;
 
     @Shadow
     @Final
-    private List<Suggestion> suggestions;
+    private List<Suggestion> suggestionList;
 
-    @Inject(method = "complete", at = @At("TAIL"))
+    @Inject(method = "useSuggestion", at = @At("TAIL"))
     private void onComplete(CallbackInfo callbackInfo) {
-        ChatInputSuggestorAccessor inputSuggestor = (ChatInputSuggestorAccessor) this.field_21615;
-        if (inputSuggestor == null) {
+        if (this.suggestionList == null || this.suggestionList.isEmpty()) {
             return;
         }
-        
-        if (this.suggestions == null || this.suggestions.isEmpty()) {
+        if (this.current < 0 || this.current >= this.suggestionList.size()) {
             return;
         }
-        if (this.selection < 0 || this.selection >= this.suggestions.size()) {
-            return;
-        }
-        
-        TextFieldWidget textFieldWidget = inputSuggestor.getTextField();
-        Suggestion suggestion = this.suggestions.get(this.selection);
+
+        EditBox input = ((ChatInputSuggestorAccessor) this.this$0).emojitype$getInput();
+        Suggestion suggestion = this.suggestionList.get(this.current);
 
         for (EmojiCode emojiCode : EmojiType.getActiveEmojiCodes()) {
             if (suggestion.getText().equals(emojiCode.getChatSuggestion())) {
-                int suggestionLength = emojiCode.getChatSuggestion().length();
-                textFieldWidget.eraseCharacters(-suggestionLength);
-                textFieldWidget.setSelectionEnd(textFieldWidget.getCursor());
-                textFieldWidget.write(emojiCode.getEmoji());
+                String value = input.getValue().replace(emojiCode.getChatSuggestion(), emojiCode.getEmoji());
+                input.setValue(value);
+                input.setCursorPosition(Math.min(input.getCursorPosition(), value.length()));
                 break;
             }
         }

--- a/common/src/main/java/dev/norbiros/emojitype/mixin/TextFieldWidgetMixin.java
+++ b/common/src/main/java/dev/norbiros/emojitype/mixin/TextFieldWidgetMixin.java
@@ -2,8 +2,8 @@ package dev.norbiros.emojitype.mixin;
 
 import dev.norbiros.emojitype.EmojiType;
 import dev.norbiros.emojitype.emoji.EmojiCode;
-import net.minecraft.client.gui.widget.TextFieldWidget;
-import net.minecraft.client.input.CharInput;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.input.CharacterEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -12,41 +12,42 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.Objects;
 
-@Mixin(TextFieldWidget.class)
+@Mixin(EditBox.class)
 public abstract class TextFieldWidgetMixin {
     @Shadow
-    private String text;
+    private String value;
 
     @Shadow
-    private int selectionStart;
+    private int cursorPos;
 
     @Shadow
-    private int selectionEnd;
+    private int highlightPos;
 
     @Shadow
-    public abstract String getText();
+    public abstract String getValue();
 
     @Shadow
-    protected abstract void onChanged(String newText);
+    private void onValueChange(String newText) {
+    }
 
     @Inject(method = "charTyped", at = @At("RETURN"))
-    private void onCharTyped(CharInput input, CallbackInfoReturnable<Boolean> callbackInfo) {
+    private void onCharTyped(CharacterEvent input, CallbackInfoReturnable<Boolean> callbackInfo) {
         if (!callbackInfo.getReturnValue()) {
             return;
         }
 
-        String result = getText();
+        String result = getValue();
         for (EmojiCode emojiCode : EmojiType.getActiveEmojiCodes()) {
             result = result.replace(emojiCode.getCodeWithColons(), emojiCode.getEmoji());
         }
 
-        if (!Objects.equals(this.text, result)) {
-            int lengthDifference = this.text.length() - result.length();
-            int newCursorPosition = Math.max(Math.min(this.selectionEnd - lengthDifference + 1, result.length()), 0);
-            this.selectionEnd = this.selectionStart = newCursorPosition;
+        if (!Objects.equals(this.value, result)) {
+            int lengthDifference = this.value.length() - result.length();
+            int newCursorPosition = Math.max(Math.min(this.highlightPos - lengthDifference + 1, result.length()), 0);
+            this.highlightPos = this.cursorPos = newCursorPosition;
         }
 
-        this.text = result;
-        this.onChanged(result);
+        this.value = result;
+        this.onValueChange(result);
     }
 }

--- a/common/src/main/java/dev/norbiros/emojitype/packs/PackType.java
+++ b/common/src/main/java/dev/norbiros/emojitype/packs/PackType.java
@@ -1,6 +1,6 @@
 package dev.norbiros.emojitype.packs;
 
-import net.minecraft.text.Text;
+import net.minecraft.network.chat.Component;
 
 public enum PackType {
     BUNDLED("bundled"),
@@ -30,8 +30,8 @@ public enum PackType {
         return id;
     }
 
-    public Text getTranslatedLabel() {
-        return Text.translatable("config.emojitype.pack_type." + id);
+    public Component getTranslatedLabel() {
+        return Component.translatable("config.emojitype.pack_type." + id);
     }
 
     @Override

--- a/common/src/main/resources/emojitype-common.mixins.json
+++ b/common/src/main/resources/emojitype-common.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "dev.norbiros.emojitype.mixin",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_25",
   "mixins": [
   ],
   "client": [

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,43 +1,41 @@
-architectury {
-    platformSetupLoomIde()
-    fabric()
+plugins {
+    alias(libs.plugins.fabric.loom)
 }
 
-val commonConfig = configurations.getByName("common")
-val shadowCommonConfig = configurations.getByName("shadowCommon")
-val developmentFabricConfig = configurations.getByName("developmentFabric")
-
-configurations {
-    compileClasspath.get().extendsFrom(commonConfig)
-    runtimeClasspath.get().extendsFrom(commonConfig)
-    developmentFabricConfig.extendsFrom(commonConfig)
+sourceSets {
+    main {
+        java.srcDir(rootProject.file("common/src/main/java"))
+        java.exclude(
+            "dev/norbiros/emojitype/config/ui/ConfirmationDialog.java",
+            "dev/norbiros/emojitype/config/ui/EmojiListWidget.java",
+            "dev/norbiros/emojitype/config/ui/PackEditorScreen.java",
+            "dev/norbiros/emojitype/config/ui/PackListWidget.java",
+            "dev/norbiros/emojitype/config/ui/PackPropertiesDialog.java",
+            "dev/norbiros/emojitype/config/ui/UIColors.java",
+        )
+        resources.srcDir(rootProject.file("common/src/main/resources"))
+    }
 }
 
 dependencies {
-    "modImplementation"(libs.fabric.loader)
-    "modApi"(libs.modmenu)
-
+    add("minecraft", libs.minecraft)
+    implementation(libs.fabric.loader)
+    implementation(libs.modmenu)
+    implementation(libs.snakeyaml)
     include(libs.snakeyaml)
-
-    common(project(path = ":common", configuration = "namedElements")) { isTransitive = false }
-    shadowCommon(project(path = ":common", configuration = "transformProductionFabric")) { isTransitive = false }
 }
 
-tasks.remapJar {
-    inputFile.set(tasks.shadowJar.get().archiveFile)
-    dependsOn(tasks.shadowJar)
-    archiveClassifier.set("fabric")
-}
+tasks.processResources {
+    val replaceProperties = mapOf(
+        "version" to project.property("mod_version"),
+        "fabric_minecraft_version_range" to project.property("fabric_minecraft_version_range"),
+        "fabric_loader_version" to libs.versions.fabric.loader.get(),
+        "modmenu_version" to libs.versions.modmenu.get(),
+    )
 
-tasks.sourcesJar {
-    val commonSources = project(":common").tasks.getByName<Jar>("sourcesJar")
-    dependsOn(commonSources)
-    from(commonSources.archiveFile.map { zipTree(it) })
-}
-
-components.getByName<AdhocComponentWithVariants>("java") {
-    withVariantsFromConfiguration(configurations["shadowRuntimeElements"]) {
-        skip()
+    inputs.properties(replaceProperties)
+    filesMatching("fabric.mod.json") {
+        expand(replaceProperties)
     }
 }
 

--- a/fabric/src/main/java/dev/norbiros/emojitype/fabric/EmojiTypeImpl.java
+++ b/fabric/src/main/java/dev/norbiros/emojitype/fabric/EmojiTypeImpl.java
@@ -2,18 +2,8 @@ package dev.norbiros.emojitype.fabric;
 
 import dev.norbiros.emojitype.EmojiType;
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.loader.api.FabricLoader;
-
-import java.nio.file.Path;
 
 public class EmojiTypeImpl extends EmojiType implements ModInitializer {
-    /**
-     * Implementation of {@link EmojiType#getConfigDirectory()}.
-     */
-    public static Path getConfigDirectory() {
-        return FabricLoader.getInstance().getConfigDir();
-    }
-
     @Override
     public void onInitialize() {
         EmojiType.init();

--- a/fabric/src/main/resources/emojitype.mixins.json
+++ b/fabric/src/main/resources/emojitype.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "dev.norbiros.emojitype.mixin.fabric",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_25",
   "mixins": [
   ],
   "client": [

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,12 @@
 org.gradle.jvmargs=-Xmx2G
+org.gradle.configuration-cache=false
 mod_id=emoji-type
-mod_version=3.0.0-1.21.10
-java_version=21
+mod_version=3.0.0-26.1.2
+java_version=25
 maven_group=dev.norbiros
 # Loader specific
-fabric_minecraft_version_range=~1.21.9
+fabric_minecraft_version_range=~26.1.2
 neo_minecraft_version_range=[21.9, 22)
 # Architectury
-enabled_platforms=fabric,neoforge
+enabled_platforms=fabric
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,16 +2,13 @@
 # https://linkie.shedaniel.me/dependencies
 
 [versions]
-minecraft = "1.21.10"
-fabric-loader = "0.18.1"
-yarn-mappings = "1.21.10+build.3"
+minecraft = "26.1.2"
+fabric-loader = "0.19.2"
 neoforge = "21.10.55-beta"
 neoforge-yarn-mappings-patch = "1.21+build.6"
-modmenu = "16.0.0-rc.1"
+modmenu = "18.0.0-alpha.8"
 snakeyaml = "2.5"
-shadow = "8.3.5"
-architectury-plugin = "3.4-SNAPSHOT"
-architectury-loom = "1.10-SNAPSHOT"
+fabric-loom = "1.16-SNAPSHOT"
 
 [libraries]
 minecraft = { module = "com.mojang:minecraft", version.ref = "minecraft" }
@@ -20,12 +17,6 @@ fabric-loader = { module = "net.fabricmc:fabric-loader", version.ref = "fabric-l
 modmenu = { module = "com.terraformersmc:modmenu", version.ref = "modmenu" }
 neoforge = { module = "net.neoforged:neoforge", version.ref = "neoforge" }
 
-# Mappings
-yarn-mappings = { module = "net.fabricmc:yarn", version.ref = "yarn-mappings" }
-neoforge-yarn-mappings-patch = { module = "dev.architectury:yarn-mappings-patch-neoforge", version.ref = "neoforge-yarn-mappings-patch" }
-
 [plugins]
-shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
-architectury = { id = "architectury-plugin", version.ref = "architectury-plugin" }
-architectury-loom = { id = "dev.architectury.loom", version.ref = "architectury-loom" }
+fabric-loom = { id = "net.fabricmc.fabric-loom", version.ref = "fabric-loom" }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,15 +1,11 @@
 pluginManagement {
     repositories {
         maven("https://maven.fabricmc.net/")
-        maven("https://maven.architectury.dev/")
-        maven("https://maven.neoforged.net/")
         gradlePluginPortal()
     }
 }
 
-include("common")
 include("fabric")
-include("neoforge")
 
 rootProject.name = "emojitype"
 


### PR DESCRIPTION
### 🟠 add Fabric 26.1.2 Support
- **Summary** - Added Fabric-focused Minecraft 26.1.2 support for Emoji Type.
- **Description** - The active Gradle build now targets Fabric on Minecraft 26.1.2 using Fabric Loom 1.16, Java 25, Fabric Loader 0.19.2, and Mod Menu 18. NeoForge remains present in the repo but is not included in the active 26.1.2 build.

- **Changes** - Reworked the build away from Architectury for the Fabric path, updated version metadata and Gradle wrapper, migrated active Minecraft API usage to official 26.1.2 names, restored chat emoji tab-completion via `CommandSuggestions`, updated mixin compatibility to Java 25, simplified the Mod Menu config screen for the new GUI API.

- **Changelog** _(Changes done after the first commit of this PR)_
  - Fixed a bug that caused the game to crash when opening signs. 

 
### This is for Fabric only for now.

### "Normal" people (who don't compile it themself) can get the `.jar` from https://github.com/pxlarified/emojitype/releases.